### PR TITLE
VMActions: update the VM table after Migration

### DIFF
--- a/src/components/VMManager.jsx
+++ b/src/components/VMManager.jsx
@@ -17,6 +17,13 @@ class VMManager extends React.Component {
     this.setState({ selectedVM: vm });
   };
 
+  updateSelectedVM = (VMlist) => {
+    if (this.state.selectedVM) {
+      const updatedSelectedVM = VMlist.find(vm => vm.id === this.state.selectedVM.id);
+      this.setState({ selectedVM: updatedSelectedVM });
+    }
+  };
+
   render() {
     const { selectedVM } = this.state;
 
@@ -24,7 +31,7 @@ class VMManager extends React.Component {
       <VMData render={(VMlist, refreshVMList) => (
         <div>
           <VMTable VMlist={VMlist} selectedVM={selectedVM} onRowClick={this.handleRowClick} />
-          <VMActions selectedVM={selectedVM} refreshVMList={refreshVMList}/>
+          <VMActions VMlist={VMlist} selectedVM={selectedVM} refreshVMList={refreshVMList} updateSelectedVM={this.updateSelectedVM}/>
         </div>
       )} />
     );


### PR DESCRIPTION
Fixes information about a VM migrated to another node. The view is refreshed after the spawn command returns a resolved promise. But in the specific case of a migration, the promise is resolved after the default node policy has been changed, not at the end of the migration.