### PR TITLE
VMActions: remove migration to same host choice

### DIFF
--- a/src/components/VMActions.jsx
+++ b/src/components/VMActions.jsx
@@ -163,7 +163,11 @@ class VMActions extends React.Component {
       // If there is a match with the regex and the online node list is not empty, we collect them in an array
       const onlineNodes = onlineMatch && onlineMatch[1] ? onlineMatch[1].split(' ') : [];
 
-      return onlineNodes;
+      const filteredNodes = onlineNodes.filter(node => {
+          return !node.includes(selectedVM.currentNode.trim());
+      });
+
+      return filteredNodes;
     } catch (error) {
       console.error("Error executing VM action:", error);
       return [];


### PR DESCRIPTION
To perform the migration, the drop-down list proposed all online nodes. But migrating to the same host on which the virtual machine is running is not suitable. It was also causing an infinite refresh of the view due to the pooling condition.