### PR TITLE
VMActions: Improve VM table updating after migration

### DIFF
--- a/src/components/VMManager.jsx
+++ b/src/components/VMManager.jsx
@@ -21,13 +21,6 @@ class VMManager extends React.Component {
     this.setState({ selectedVM: vm });
   };
 
-  updateSelectedVM = (VMlist) => {
-    if (this.state.selectedVM) {
-      const updatedSelectedVM = VMlist.find(vm => vm.id === this.state.selectedVM.id);
-      this.setState({ selectedVM: updatedSelectedVM });
-    }
-  };
-
   openVMCreator = () => {
     this.setState({ isVMCreatorOpen: true });
   };
@@ -46,7 +39,7 @@ class VMManager extends React.Component {
             <Button variant="primary" onClick={this.openVMCreator}>Create VM</Button>
           </div>
           <VMTable VMlist={VMlist} selectedVM={selectedVM} onRowClick={this.handleRowClick} />
-          <VMActions VMlist={VMlist} selectedVM={selectedVM} refreshVMList={refreshVMList} updateSelectedVM={this.updateSelectedVM}/>
+          <VMActions VMlist={VMlist} selectedVM={selectedVM} refreshVMList={refreshVMList} />
           <VMCreator
             isOpen={isVMCreatorOpen}
             onClose={this.closeVMCreator}


### PR DESCRIPTION
This commit removes the correlation between the table of VMs displayed, and the pooling performed to update the status of a VM after its migration. The previous version updated the view to obtain VM status every 3 seconds, causing the VM table to blink.

Pooling is now performed every second, but the view is only updated if the VM is in the "Started" state or if 15 seconds have elapsed.