### PR TITLE
VMData: fix display of empty VM list

### DIFF
--- a/src/components/VMData.jsx
+++ b/src/components/VMData.jsx
@@ -24,7 +24,12 @@ class VMData extends React.Component {
   fetchVmInformations = async () => {
     try {
       const output = await cockpit.spawn(["vm-mgr", "list"], { superuser: "try" });
-      const vmNames = output.trim().split('\n');
+      const vmNames = output.trim().split('\n').filter(name => name !== "");
+
+      if (vmNames.length === 0) {
+        this.setState({ VMlist: [] });
+        return;
+      }
 
       const VMlist = vmNames.map((name, index) => ({
         id: index + 1,


### PR DESCRIPTION
If no VMs were deployed on the cluster, the “output” variable contained an empty element.making statusPromises calling “vm-mgr status” with an empty VM name. This case is now detected and will stop the fetch of VM information.