### PR TITLE
package.json: change xterm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@patternfly/react-styles": "5.3.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "@xterm/xterm": "5.5.0",
-    "@xterm/addon-canvas": "0.7.0"
+    "xterm": "5.1.0",
+    "xterm-addon-canvas": "0.5.0"
   }
 }


### PR DESCRIPTION
The xterm dependency is required for Cockpit-components-terminal.jsx. The version of Cockpit used in SEAPATH does not include the “build: Switch to @xterm/xterm and @xterm/addon-canvas” modifications
(commit SHA: c9096a71671be75c3d99331c075d6585f2c6d162).
Therefore, an older version of xterm must be used.