### PR TITLE
VMCreator: add location preference and VM creation progress

### DIFF
--- a/src/components/VMCreator.jsx
+++ b/src/components/VMCreator.jsx
@@ -135,7 +135,7 @@ class VMCreator extends React.Component {
             />
           </FormGroup>
 
-          <FormGroup label="Path VM Image *" fieldId="path-vm-image">
+          <FormGroup label="Path VM Image" fieldId="path-vm-image">
             <div style={{ display: 'flex', alignItems: 'center', marginBottom: '10px' }}>
               <FileAutoComplete
                 id="path-vm-image"
@@ -155,7 +155,7 @@ class VMCreator extends React.Component {
             )}
           </FormGroup>
 
-          <FormGroup label="Path VM XML *" fieldId="path-vm-xml">
+          <FormGroup label="Path VM XML" fieldId="path-vm-xml">
             <div style={{ display: 'flex', alignItems: 'center', marginBottom: '10px' }}>
               <FileAutoComplete
                 id="path-vm-xml"
@@ -193,13 +193,7 @@ class VMCreator extends React.Component {
 
 
         </Form>
-
         <br />
-        <div style={{ fontSize: '12px' }}>
-          (* path from the host machine)
-        </div>
-        <br />
-
         {isLoading && <div style={{textAlign: "center"}}> {this.state.progressVMCreation} </div>}
       </Modal>
     );

--- a/src/components/VMCreator.jsx
+++ b/src/components/VMCreator.jsx
@@ -10,6 +10,7 @@ import {
   Alert,
   Progress,
   Checkbox,
+  Radio,
 } from '@patternfly/react-core';
 import FileUploader from './fileUploader';
 import { FileAutoComplete } from "cockpit-components-file-autocomplete.jsx";
@@ -28,6 +29,9 @@ class VMCreator extends React.Component {
       isVMCreated: null,
       isLiveMigrationEnabled: false,
       migrationUser: '',
+      isPinnedHostEnabled: false,
+      isPreferredHostEnabled: false,
+      locationHostname: ''
     };
   }
 
@@ -47,6 +51,17 @@ class VMCreator extends React.Component {
     this.setState({ migrationUser: e.target.value });
   }
 
+  handleLocationPreferenceChange = (e) => {
+    const id = e.target.id;
+    this.setState({
+      isPinnedHostEnabled: id === 'pinned-host',
+      isPreferredHostEnabled: id === 'preferred-host',
+    });
+  };
+  handleLocationHostnameChange = (e) => {
+    this.setState({ locationHostname: e.target.value });
+  }
+
   handleConfirm = () => {
     const { vmName, vmImagePath, vmXmlPath } = this.state;
     const { refreshVMList } = this.props;
@@ -56,6 +71,14 @@ class VMCreator extends React.Component {
       args.push('--enable-live-migration');
       args.push('--migration-user');
       args.push(this.state.migrationUser);
+    }
+
+    if (this.state.isPinnedHostEnabled){
+      args.push('--pinned-host');
+      args.push(this.state.locationHostname);
+    }else if (this.state.isPreferredHostEnabled){
+      args.push('--preferred-host');
+      args.push(this.state.locationHostname);
     }
 
     this.setState({ isLoading: true, isVMCreated: null });
@@ -190,6 +213,36 @@ class VMCreator extends React.Component {
               />
             </FormGroup>
           )}
+
+        <FormGroup role="radiogroup" label="Location preference" isInline>
+          <Radio
+            label="None"
+            id="none"
+            onChange={this.handleLocationPreferenceChange}
+            isChecked={!this.state.isPinnedHostEnabled && !this.state.isPreferredHostEnabled}
+          />
+          <Radio
+            label="Preferred host"
+            id="preferred-host"
+            onChange={this.handleLocationPreferenceChange}
+            isChecked={this.state.isPreferredHostEnabled}
+          />
+          <Radio
+            label="Pinned host"
+            id="pinned-host"
+            onChange={this.handleLocationPreferenceChange}
+            isChecked={this.state.isPinnedHostEnabled}
+          />
+        </FormGroup>
+        {(this.state.isPinnedHostEnabled || this.state.isPreferredHostEnabled) && (
+          <FormGroup label="Hostname" fieldId="hostname">
+            <TextInput
+              id="hostname"
+              value={this.state.locationHostname}
+              onChange={this.handleLocationHostnameChange}
+            />
+          </FormGroup>
+        )}
 
 
         </Form>

--- a/src/components/VMCreator.jsx
+++ b/src/components/VMCreator.jsx
@@ -7,7 +7,6 @@ import {
   FormGroup,
   TextInput,
   ModalVariant,
-  Spinner,
   Alert,
   Progress,
   Checkbox,
@@ -25,6 +24,7 @@ class VMCreator extends React.Component {
       vmXmlPath: '',
       progressUploadXML: 0,
       progressUploadQCOW: 0,
+      progressVMCreation: '',
       isVMCreated: null,
       isLiveMigrationEnabled: false,
       migrationUser: '',
@@ -59,7 +59,10 @@ class VMCreator extends React.Component {
     }
 
     this.setState({ isLoading: true, isVMCreated: null });
-    cockpit.spawn(["vm-mgr", "create", "--name", vmName, "--image", vmImagePath, "--xml", vmXmlPath, ...args], { superuser: "try" })
+    cockpit.spawn(["vm-mgr", "create", "-p", "--name", vmName, "--image", vmImagePath, "--xml", vmXmlPath, ...args], { superuser: "try" })
+      .stream((output) => {
+        this.setState({ progressVMCreation: output.trim() });
+      })
       .then(() => {
         this.setState({ isVMCreated: true });
         refreshVMList();
@@ -197,7 +200,7 @@ class VMCreator extends React.Component {
         </div>
         <br />
 
-        {isLoading && <Spinner size="lg" style={{ marginTop: '20px' }} />}
+        {isLoading && <div style={{textAlign: "center"}}> {this.state.progressVMCreation} </div>}
       </Modal>
     );
   }


### PR DESCRIPTION
- The location of the VM can now be chosen (location type and host)
- The new vm_mgr ("--progress" or "-p") option has been used to display the status of the VM creation in percent.
- The footnote has been removed since the FileUploader components already displays the information.