### PR TITLE
publish-github-packages: add release workflow

### DIFF
--- a/.github/workflows/publish-github-packages.yml
+++ b/.github/workflows/publish-github-packages.yml
@@ -1,0 +1,29 @@
+name: Build and publish Cockpit cluster vm management plugin
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - run: npm run init
+
+      - name: Pack dist folder
+        run: tar -czvf cockpit-cluster-vm-management.tar.gz -C dist/ .
+
+      - name: Upload artifact
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./cockpit-cluster-vm-management.tar.gz
+          asset_name: cockpit-cluster-vm-management.tar.gz
+          asset_content_type: application/gzip


### PR DESCRIPTION
This github action workflow publishes the cockpit-cluster-dashboard plugin to the GitHub Releases page as a tarball.

Installing this plugin simply requires downloading the tarball and extracting it to
`/usr/share/cockpit/plugins/cockpit-cluster-vm-management`.