### PR TITLE
components: enable live migration by default and hardcode migration user

### DIFF
--- a/src/components/VMCreator.jsx
+++ b/src/components/VMCreator.jsx
@@ -30,8 +30,7 @@ class VMCreator extends React.Component {
       progressVMCreation: '',
       isVMCreated: null,
       diskBusType: 'virtio',
-      isLiveMigrationEnabled: false,
-      migrationUser: '',
+      isLiveMigrationEnabled: true,
       isPinnedHostEnabled: false,
       isPreferredHostEnabled: false,
       locationHostname: ''
@@ -54,10 +53,6 @@ class VMCreator extends React.Component {
     this.setState({ diskBusType });
   }
 
-  handleMigrationUserChange = (e) => {
-    this.setState({ migrationUser: e.target.value });
-  }
-
   handleLocationPreferenceChange = (e) => {
     const id = e.target.id;
     this.setState({
@@ -77,7 +72,7 @@ class VMCreator extends React.Component {
     if (this.state.isLiveMigrationEnabled) {
       args.push('--enable-live-migration');
       args.push('--migration-user');
-      args.push(this.state.migrationUser);
+      args.push('libvirtadmin');
     }
 
     if (this.state.isPinnedHostEnabled){
@@ -222,16 +217,6 @@ class VMCreator extends React.Component {
             isChecked={this.state.isLiveMigrationEnabled}
             onChange={this.handleCheckboxChange}
           />
-          {this.state.isLiveMigrationEnabled && (
-            <FormGroup label="Migration User" fieldId="migration-user">
-              <TextInput
-                id="migration-user"
-                value={this.state.migrationUser}
-                onChange={this.handleMigrationUserChange}
-              />
-            </FormGroup>
-          )}
-
         <FormGroup role="radiogroup" label="Location preference" isInline>
           <Radio
             label="None"

--- a/src/components/VMImporter.jsx
+++ b/src/components/VMImporter.jsx
@@ -31,8 +31,7 @@ class VMImporter extends React.Component {
       isLoading: false,
       isImported: null,
       progressImport: '',
-      isLiveMigrationEnabled: false,
-      migrationUser: '',
+      isLiveMigrationEnabled: true,
       isPinnedHostEnabled: false,
       isPreferredHostEnabled: false,
       locationHostname: '',
@@ -74,10 +73,6 @@ class VMImporter extends React.Component {
     this.setState({ isLiveMigrationEnabled: !this.state.isLiveMigrationEnabled });
   };
 
-  handleMigrationUserChange = (e) => {
-    this.setState({ migrationUser: e.target.value });
-  };
-
   handleLocationPreferenceChange = (e) => {
     const id = e.target.id;
     this.setState({
@@ -98,7 +93,7 @@ class VMImporter extends React.Component {
     if (this.state.isLiveMigrationEnabled) {
       args.push('--enable-live-migration');
       args.push('--migration-user');
-      args.push(this.state.migrationUser);
+      args.push('libvirtadmin');
     }
 
     if (this.state.isPinnedHostEnabled) {
@@ -181,16 +176,6 @@ class VMImporter extends React.Component {
             isChecked={this.state.isLiveMigrationEnabled}
             onChange={this.handleCheckboxChange}
           />
-          {this.state.isLiveMigrationEnabled && (
-            <FormGroup label="Migration User" fieldId="import-migration-user">
-              <TextInput
-                id="import-migration-user"
-                value={this.state.migrationUser}
-                onChange={this.handleMigrationUserChange}
-              />
-            </FormGroup>
-          )}
-
           <FormGroup role="radiogroup" label="Location preference" isInline>
             <Radio
               label="None"


### PR DESCRIPTION
The migration user is now hardcoded to 'libvirtadmin' and the live migration option is enabled by default in both the VM Creator and VM Importer components. The migration user is now well-defined on SEAPATH and does not need to be set by the user.