### PR TITLE
VMCreator: add XML-free form-based VM creation

### DIFF
--- a/docs/vm-template-variables.md
+++ b/docs/vm-template-variables.md
@@ -1,0 +1,35 @@
+# VM Creation Form to Template Variable Mapping
+
+This document maps the VMCreator form fields to the corresponding variables
+used in the `guest.xml.j2` Jinja2 template.
+
+## Core Fields
+
+| Form Field | Template Variable | Notes |
+|---|---|---|
+| VM Name | `vm.inventory_hostname` | Used as `<name>` in domain XML |
+| vcpuCount | `vm.nb_cpu` | Fallback when `cpuset` is not defined |
+| cpuPinning | `vm.cpuset` | RT only; also adds `isolated` to `vm_features` |
+| hostPassthrough | `cpu mode` attribute | `host-passthrough` (RT) vs `host-model` |
+| rtPriority | `vm.rt_priority` | RT only, default 1 |
+| emulatorPin | `vm.emulatorpin` | RT only |
+| memorySize | `vm.memory` | MiB normally, GiB when hugepages enabled |
+
+## Feature Flags (vm_features)
+
+| Form Field | vm_features entry | Notes |
+|---|---|---|
+| Real-time | `rt` | Enables RT scheduling, PMU off, host-passthrough |
+| balloon | `memballoon` | Enables virtio memballoon device |
+| hugepages | — | Uses `dpdk`-like memory path (1G hugepages) |
+| video (VNC) | `graphic-console` | Enables VNC graphics + virtio video |
+
+## Network Interfaces
+
+| Interface Type | Template Variable | Fields |
+|---|---|---|
+| Bridge | `vm.bridges[]` | `name` (source), `mac_address`, `type` (virtualport), `vlan.vlan_tag` |
+| MacvTap | `vm.direct_interfaces[]` | `source`, `mode`, `mac_address` |
+| PCI passthrough | `vm.pci_passthrough[]` | Parsed from address string: `domain`, `bus`, `slot`, `function` |
+| Libvirt network | `vm.sriov[]` | Network name passed as string |
+| SR-IOV pool | `vm.sriov[]` | Pool name passed as string (same template path as libvirt network) |

--- a/src/components/CPUConfig.jsx
+++ b/src/components/CPUConfig.jsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2026 Savoir-faire Linux Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Checkbox,
+  FormGroup,
+  TextInput,
+} from '@patternfly/react-core';
+
+class CPUConfig extends React.Component {
+  render() {
+    const {
+      vcpuCount,
+      hostPassthrough,
+      isRealtime,
+      cpuPinning,
+      rtPriority,
+      emulatorPin,
+      onVcpuCountChange,
+      onHostPassthroughChange,
+      onCpuPinningChange,
+      onRtPriorityChange,
+      onEmulatorPinChange,
+    } = this.props;
+
+    return (
+      <>
+        <FormGroup label="Number of vCPUs" fieldId="vcpu-count">
+          <TextInput
+            id="vcpu-count"
+            type="number"
+            min={1}
+            value={vcpuCount}
+            onChange={onVcpuCountChange}
+          />
+        </FormGroup>
+
+        <Checkbox
+          id="host-passthrough"
+          label="Copy host CPU configuration (host-passthrough)"
+          isChecked={hostPassthrough}
+          isDisabled={isRealtime}
+          onChange={onHostPassthroughChange}
+        />
+
+        {isRealtime && (
+          <>
+            {cpuPinning.map((cpuset, index) => (
+              <FormGroup
+                key={index}
+                label={`vCPU ${index} → cpuset`}
+                fieldId={`cpu-pinning-${index}`}
+              >
+                <TextInput
+                  id={`cpu-pinning-${index}`}
+                  value={cpuset}
+                  onChange={(e) => onCpuPinningChange(index, e.target.value)}
+                  placeholder="e.g. 2"
+                />
+              </FormGroup>
+            ))}
+
+            <FormGroup label="RT priority" fieldId="rt-priority">
+              <TextInput
+                id="rt-priority"
+                type="number"
+                min={1}
+                value={rtPriority}
+                onChange={onRtPriorityChange}
+              />
+            </FormGroup>
+
+            <FormGroup label="Emulator pin cpuset" fieldId="emulator-pin">
+              <TextInput
+                id="emulator-pin"
+                value={emulatorPin}
+                onChange={onEmulatorPinChange}
+                placeholder="e.g. 0-1"
+              />
+            </FormGroup>
+          </>
+        )}
+      </>
+    );
+  }
+}
+
+CPUConfig.propTypes = {
+  vcpuCount: PropTypes.number.isRequired,
+  hostPassthrough: PropTypes.bool.isRequired,
+  isRealtime: PropTypes.bool.isRequired,
+  cpuPinning: PropTypes.arrayOf(PropTypes.string).isRequired,
+  rtPriority: PropTypes.number.isRequired,
+  emulatorPin: PropTypes.string.isRequired,
+  onVcpuCountChange: PropTypes.func.isRequired,
+  onHostPassthroughChange: PropTypes.func.isRequired,
+  onCpuPinningChange: PropTypes.func.isRequired,
+  onRtPriorityChange: PropTypes.func.isRequired,
+  onEmulatorPinChange: PropTypes.func.isRequired,
+};
+
+export default CPUConfig;

--- a/src/components/DisplayConfig.jsx
+++ b/src/components/DisplayConfig.jsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026 Savoir-faire Linux Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Checkbox,
+  FormGroup,
+} from '@patternfly/react-core';
+
+class DisplayConfig extends React.Component {
+  render() {
+    const {
+      isSerialConsoleEnabled,
+      isVideoEnabled,
+      onSerialConsoleChange,
+      onVideoChange,
+    } = this.props;
+
+    return (
+      <>
+        <FormGroup label="Display" hasNoPaddingTop>
+          <Checkbox
+            id="enable-serial-console"
+            label="Enable serial console"
+            isChecked={isSerialConsoleEnabled}
+            onChange={onSerialConsoleChange}
+          />
+          <Checkbox
+            id="enable-video"
+            label="Enable video (VNC)"
+            isChecked={isVideoEnabled}
+            onChange={onVideoChange}
+          />
+        </FormGroup>
+      </>
+    );
+  }
+}
+
+DisplayConfig.propTypes = {
+  isSerialConsoleEnabled: PropTypes.bool.isRequired,
+  isVideoEnabled: PropTypes.bool.isRequired,
+  onSerialConsoleChange: PropTypes.func.isRequired,
+  onVideoChange: PropTypes.func.isRequired,
+};
+
+export default DisplayConfig;

--- a/src/components/MemoryConfig.jsx
+++ b/src/components/MemoryConfig.jsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2026 Savoir-faire Linux Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Checkbox,
+  FormGroup,
+  TextInput,
+} from '@patternfly/react-core';
+
+class MemoryConfig extends React.Component {
+  render() {
+    const {
+      memorySize,
+      isRealtime,
+      isBalloonEnabled,
+      balloonMinAllocation,
+      isHugepagesEnabled,
+      hugepagesCount,
+      onMemorySizeChange,
+      onBalloonChange,
+      onBalloonMinAllocationChange,
+      onHugepagesChange,
+      onHugepagesCountChange,
+    } = this.props;
+
+    return (
+      <>
+        {isRealtime && isHugepagesEnabled ? (
+          <FormGroup label="Number of 1GB hugepages" fieldId="hugepages-count">
+            <TextInput
+              id="hugepages-count"
+              type="number"
+              min={1}
+              value={hugepagesCount}
+              onChange={onHugepagesCountChange}
+            />
+          </FormGroup>
+        ) : (
+          <FormGroup label="Memory size (MiB)" fieldId="memory-size">
+            <TextInput
+              id="memory-size"
+              type="number"
+              min={1}
+              value={memorySize}
+              onChange={onMemorySizeChange}
+            />
+          </FormGroup>
+        )}
+
+        {!isRealtime && (
+          <>
+            <Checkbox
+              id="enable-balloon"
+              label="Enable balloon"
+              isChecked={isBalloonEnabled}
+              onChange={onBalloonChange}
+            />
+            {isBalloonEnabled && (
+              <FormGroup label="Minimal allocation (MiB)" fieldId="balloon-min-allocation">
+                <TextInput
+                  id="balloon-min-allocation"
+                  type="number"
+                  min={1}
+                  value={balloonMinAllocation}
+                  onChange={onBalloonMinAllocationChange}
+                />
+              </FormGroup>
+            )}
+          </>
+        )}
+
+        {isRealtime && (
+          <Checkbox
+            id="enable-hugepages"
+            label="Use 1G hugepages"
+            isChecked={isHugepagesEnabled}
+            onChange={onHugepagesChange}
+          />
+        )}
+      </>
+    );
+  }
+}
+
+MemoryConfig.propTypes = {
+  memorySize: PropTypes.number.isRequired,
+  isRealtime: PropTypes.bool.isRequired,
+  isBalloonEnabled: PropTypes.bool.isRequired,
+  balloonMinAllocation: PropTypes.number.isRequired,
+  isHugepagesEnabled: PropTypes.bool.isRequired,
+  hugepagesCount: PropTypes.number.isRequired,
+  onMemorySizeChange: PropTypes.func.isRequired,
+  onBalloonChange: PropTypes.func.isRequired,
+  onBalloonMinAllocationChange: PropTypes.func.isRequired,
+  onHugepagesChange: PropTypes.func.isRequired,
+  onHugepagesCountChange: PropTypes.func.isRequired,
+};
+
+export default MemoryConfig;

--- a/src/components/NetworkConfig.jsx
+++ b/src/components/NetworkConfig.jsx
@@ -15,7 +15,6 @@ import {
 
 const INTERFACE_TYPES = [
   { value: 'bridge', label: 'Bridge' },
-  { value: 'network', label: 'Libvirt network' },
   { value: 'macvtap', label: 'MacvTap' },
   { value: 'pci', label: 'PCI passthrough' },
   { value: 'sriov', label: 'SR-IOV pool' },
@@ -61,20 +60,6 @@ class NetworkConfig extends React.Component {
           />
         </FormGroup>
       </>
-    );
-  }
-
-  renderNetworkFields(iface) {
-    const { onInterfaceChange } = this.props;
-    return (
-      <FormGroup label="Network name" fieldId={`network-name-${iface.id}`}>
-        <TextInput
-          id={`network-name-${iface.id}`}
-          value={iface.networkName}
-          onChange={(e) => onInterfaceChange(iface.id, 'networkName', e.target.value)}
-          placeholder="e.g. default"
-        />
-      </FormGroup>
     );
   }
 
@@ -144,7 +129,6 @@ class NetworkConfig extends React.Component {
   renderInterfaceFields(iface) {
     switch (iface.type) {
       case 'bridge': return this.renderBridgeFields(iface);
-      case 'network': return this.renderNetworkFields(iface);
       case 'macvtap': return this.renderMacvtapFields(iface);
       case 'pci': return this.renderPciFields(iface);
       case 'sriov': return this.renderSriovFields(iface);

--- a/src/components/NetworkConfig.jsx
+++ b/src/components/NetworkConfig.jsx
@@ -1,0 +1,204 @@
+/*
+ * Copyright (C) 2026 Savoir-faire Linux Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Button,
+  FormGroup,
+  FormSelect,
+  FormSelectOption,
+  TextInput,
+} from '@patternfly/react-core';
+
+const INTERFACE_TYPES = [
+  { value: 'bridge', label: 'Bridge' },
+  { value: 'network', label: 'Libvirt network' },
+  { value: 'macvtap', label: 'MacvTap' },
+  { value: 'pci', label: 'PCI passthrough' },
+  { value: 'sriov', label: 'SR-IOV pool' },
+];
+
+const MACVTAP_MODES = ['vepa', 'bridge', 'private', 'passthrough'];
+
+class NetworkConfig extends React.Component {
+  renderBridgeFields(iface) {
+    const { onInterfaceChange } = this.props;
+    return (
+      <>
+        <FormGroup label="Bridge source" fieldId={`bridge-source-${iface.id}`}>
+          <TextInput
+            id={`bridge-source-${iface.id}`}
+            value={iface.bridgeSource}
+            onChange={(e) => onInterfaceChange(iface.id, 'bridgeSource', e.target.value)}
+            placeholder="e.g. br0"
+          />
+        </FormGroup>
+        <FormGroup label="MAC address" fieldId={`bridge-mac-${iface.id}`}>
+          <TextInput
+            id={`bridge-mac-${iface.id}`}
+            value={iface.bridgeMac}
+            onChange={(e) => onInterfaceChange(iface.id, 'bridgeMac', e.target.value)}
+            placeholder="e.g. 52:54:00:xx:xx:xx"
+          />
+        </FormGroup>
+        <FormGroup label="VLAN tag (optional)" fieldId={`bridge-vlan-${iface.id}`}>
+          <TextInput
+            id={`bridge-vlan-${iface.id}`}
+            value={iface.bridgeVlan}
+            onChange={(e) => onInterfaceChange(iface.id, 'bridgeVlan', e.target.value)}
+            placeholder="e.g. 100"
+          />
+        </FormGroup>
+        <FormGroup label="Virtualport type (optional)" fieldId={`bridge-vport-${iface.id}`}>
+          <TextInput
+            id={`bridge-vport-${iface.id}`}
+            value={iface.bridgeVirtualportType}
+            onChange={(e) => onInterfaceChange(iface.id, 'bridgeVirtualportType', e.target.value)}
+            placeholder="e.g. openvswitch"
+          />
+        </FormGroup>
+      </>
+    );
+  }
+
+  renderNetworkFields(iface) {
+    const { onInterfaceChange } = this.props;
+    return (
+      <FormGroup label="Network name" fieldId={`network-name-${iface.id}`}>
+        <TextInput
+          id={`network-name-${iface.id}`}
+          value={iface.networkName}
+          onChange={(e) => onInterfaceChange(iface.id, 'networkName', e.target.value)}
+          placeholder="e.g. default"
+        />
+      </FormGroup>
+    );
+  }
+
+  renderMacvtapFields(iface) {
+    const { onInterfaceChange } = this.props;
+    return (
+      <>
+        <FormGroup label="Source device" fieldId={`macvtap-source-${iface.id}`}>
+          <TextInput
+            id={`macvtap-source-${iface.id}`}
+            value={iface.macvtapSource}
+            onChange={(e) => onInterfaceChange(iface.id, 'macvtapSource', e.target.value)}
+            placeholder="e.g. eth0"
+          />
+        </FormGroup>
+        <FormGroup label="Mode" fieldId={`macvtap-mode-${iface.id}`}>
+          <FormSelect
+            id={`macvtap-mode-${iface.id}`}
+            value={iface.macvtapMode}
+            onChange={(e, value) => onInterfaceChange(iface.id, 'macvtapMode', value)}
+          >
+            {MACVTAP_MODES.map((mode) => (
+              <FormSelectOption key={mode} value={mode} label={mode} />
+            ))}
+          </FormSelect>
+        </FormGroup>
+        <FormGroup label="MAC address" fieldId={`macvtap-mac-${iface.id}`}>
+          <TextInput
+            id={`macvtap-mac-${iface.id}`}
+            value={iface.macvtapMac}
+            onChange={(e) => onInterfaceChange(iface.id, 'macvtapMac', e.target.value)}
+            placeholder="e.g. 52:54:00:xx:xx:xx"
+          />
+        </FormGroup>
+      </>
+    );
+  }
+
+  renderPciFields(iface) {
+    const { onInterfaceChange } = this.props;
+    return (
+      <FormGroup label="PCI address" fieldId={`pci-address-${iface.id}`}>
+        <TextInput
+          id={`pci-address-${iface.id}`}
+          value={iface.pciAddress}
+          onChange={(e) => onInterfaceChange(iface.id, 'pciAddress', e.target.value)}
+          placeholder="e.g. 0000:03:00.0"
+        />
+      </FormGroup>
+    );
+  }
+
+  renderSriovFields(iface) {
+    const { onInterfaceChange } = this.props;
+    return (
+      <FormGroup label="SR-IOV pool name" fieldId={`sriov-pool-${iface.id}`}>
+        <TextInput
+          id={`sriov-pool-${iface.id}`}
+          value={iface.sriovPool}
+          onChange={(e) => onInterfaceChange(iface.id, 'sriovPool', e.target.value)}
+          placeholder="e.g. sriov-net-pool"
+        />
+      </FormGroup>
+    );
+  }
+
+  renderInterfaceFields(iface) {
+    switch (iface.type) {
+      case 'bridge': return this.renderBridgeFields(iface);
+      case 'network': return this.renderNetworkFields(iface);
+      case 'macvtap': return this.renderMacvtapFields(iface);
+      case 'pci': return this.renderPciFields(iface);
+      case 'sriov': return this.renderSriovFields(iface);
+      default: return null;
+    }
+  }
+
+  render() {
+    const {
+      networkInterfaces,
+      onAddInterface,
+      onRemoveInterface,
+      onInterfaceChange,
+    } = this.props;
+
+    return (
+      <>
+        <FormGroup label="Network interfaces">
+          <Button variant="secondary" onClick={onAddInterface}>
+            Add network interface
+          </Button>
+        </FormGroup>
+
+        {networkInterfaces.map((iface) => (
+          <div key={iface.id} style={{ border: '1px solid var(--pf-v5-global--BorderColor--100)', padding: '16px', marginBottom: '16px', borderRadius: '4px' }}>
+            <FormGroup label="Interface type" fieldId={`iface-type-${iface.id}`}>
+              <FormSelect
+                id={`iface-type-${iface.id}`}
+                value={iface.type}
+                onChange={(e, value) => onInterfaceChange(iface.id, 'type', value)}
+              >
+                {INTERFACE_TYPES.map((opt) => (
+                  <FormSelectOption key={opt.value} value={opt.value} label={opt.label} />
+                ))}
+              </FormSelect>
+            </FormGroup>
+
+            {this.renderInterfaceFields(iface)}
+
+            <Button variant="danger" onClick={() => onRemoveInterface(iface.id)} style={{ marginTop: '8px' }}>
+              Remove
+            </Button>
+          </div>
+        ))}
+      </>
+    );
+  }
+}
+
+NetworkConfig.propTypes = {
+  networkInterfaces: PropTypes.arrayOf(PropTypes.object).isRequired,
+  onAddInterface: PropTypes.func.isRequired,
+  onRemoveInterface: PropTypes.func.isRequired,
+  onInterfaceChange: PropTypes.func.isRequired,
+};
+
+export default NetworkConfig;

--- a/src/components/VMCreator.jsx
+++ b/src/components/VMCreator.jsx
@@ -166,7 +166,6 @@ class VMCreator extends React.Component {
       bridgeMac: '',
       bridgeVlan: '',
       bridgeVirtualportType: '',
-      networkName: '',
       macvtapSource: '',
       macvtapMode: 'vepa',
       macvtapMac: '',
@@ -193,6 +192,62 @@ class VMCreator extends React.Component {
     });
   }
 
+  buildNetArg = (iface) => {
+    switch (iface.type) {
+      case 'bridge': {
+        const parts = [`type=bridge`, `source=${iface.bridgeSource}`, `mac=${iface.bridgeMac}`];
+        if (iface.bridgeVlan) parts.push(`vlan=${iface.bridgeVlan}`);
+        if (iface.bridgeVirtualportType) parts.push(`virtualport=${iface.bridgeVirtualportType}`);
+        return parts.join(',');
+      }
+      case 'macvtap': {
+        const parts = [`type=macvtap`, `source=${iface.macvtapSource}`, `mac=${iface.macvtapMac}`];
+        if (iface.macvtapMode) parts.push(`mode=${iface.macvtapMode}`);
+        return parts.join(',');
+      }
+      case 'pci':
+        return `type=pci,address=${iface.pciAddress}`;
+      case 'sriov':
+        return `type=sriov,network=${iface.sriovPool}`;
+      default:
+        return null;
+    }
+  }
+
+  buildFormArgs = () => {
+    const args = [
+      '--vcpus', String(this.state.vcpuCount),
+      '--memory', String(this.state.memorySize),
+    ];
+    const cpuset = this.state.cpuPinning.filter((c) => c !== '').join(',');
+    if (cpuset) {
+      args.push('--cpuset', cpuset);
+    }
+    if (this.state.isRealtime) {
+      args.push('--rt');
+      args.push('--rt-priority', String(this.state.rtPriority));
+    }
+    if (this.state.emulatorPin) {
+      args.push('--emulatorpin', this.state.emulatorPin);
+    }
+    if (this.state.isHugepagesEnabled) {
+      args.push('--hugepages');
+    }
+    if (this.state.isBalloonEnabled) {
+      args.push('--balloon');
+    }
+    if (this.state.isVideoEnabled) {
+      args.push('--vnc');
+    }
+    for (const iface of this.state.networkInterfaces) {
+      const netArg = this.buildNetArg(iface);
+      if (netArg) {
+        args.push('--net', netArg);
+      }
+    }
+    return args;
+  }
+
   handleConfirm = () => {
     const { vmName, vmImagePath, vmXmlPath, diskBusType, importXml } = this.state;
     const { refreshVMList } = this.props;
@@ -212,14 +267,14 @@ class VMCreator extends React.Component {
       args.push(this.state.locationHostname);
     }
 
-    if (!importXml) {
-      // Form-based creation not yet implemented
-      console.warn("Form-based XML generation is not yet implemented");
-      return;
+    if (importXml) {
+      args.push('--xml', vmXmlPath);
+    } else {
+      args.push(...this.buildFormArgs());
     }
 
     this.setState({ isLoading: true, isVMCreated: null });
-    cockpit.spawn(["vm-mgr", "create", "-p", "--name", vmName, "--image", vmImagePath, "--xml", vmXmlPath, "--disk-bus", diskBusType, ...args], { superuser: "try" })
+    cockpit.spawn(["vm-mgr", "create", "-p", "--name", vmName, "--image", vmImagePath, "--disk-bus", diskBusType, ...args], { superuser: "try" })
       .stream((output) => {
         this.setState({ progressVMCreation: output.trim() });
       })

--- a/src/components/VMCreator.jsx
+++ b/src/components/VMCreator.jsx
@@ -16,6 +16,10 @@ import {
 } from '@patternfly/react-core';
 import FileUploader from './fileUploader';
 import { FileAutoComplete } from "cockpit-components-file-autocomplete.jsx";
+import CPUConfig from './CPUConfig';
+import MemoryConfig from './MemoryConfig';
+import DisplayConfig from './DisplayConfig';
+import NetworkConfig from './NetworkConfig';
 
 class VMCreator extends React.Component {
   constructor(props) {
@@ -33,7 +37,24 @@ class VMCreator extends React.Component {
       isLiveMigrationEnabled: true,
       isPinnedHostEnabled: false,
       isPreferredHostEnabled: false,
-      locationHostname: ''
+      locationHostname: '',
+      // New state for form-based creation
+      importXml: false,
+      isRealtime: false,
+      vcpuCount: 1,
+      hostPassthrough: false,
+      cpuPinning: [''],
+      rtPriority: 1,
+      emulatorPin: '',
+      memorySize: 2048,
+      isBalloonEnabled: false,
+      balloonMinAllocation: 1024,
+      isHugepagesEnabled: false,
+      hugepagesCount: 2,
+      isSerialConsoleEnabled: true,
+      isVideoEnabled: false,
+      networkInterfaces: [],
+      nextInterfaceId: 0,
     };
   }
 
@@ -64,8 +85,116 @@ class VMCreator extends React.Component {
     this.setState({ locationHostname: e.target.value });
   }
 
+  handleImportXmlChange = () => {
+    this.setState({ importXml: !this.state.importXml });
+  }
+
+  handleRealtimeChange = () => {
+    const newRt = !this.state.isRealtime;
+    const updates = { isRealtime: newRt };
+    if (newRt) {
+      updates.hostPassthrough = true;
+      updates.isBalloonEnabled = false;
+      updates.cpuPinning = Array.from({ length: this.state.vcpuCount }, () => '');
+    }
+    this.setState(updates);
+  }
+
+  handleVcpuCountChange = (e) => {
+    const count = Math.max(1, parseInt(e.target.value, 10) || 1);
+    const updates = { vcpuCount: count };
+    if (this.state.isRealtime) {
+      const current = this.state.cpuPinning;
+      updates.cpuPinning = Array.from({ length: count }, (_, i) => current[i] || '');
+    }
+    this.setState(updates);
+  }
+
+  handleHostPassthroughChange = () => {
+    if (!this.state.isRealtime) {
+      this.setState({ hostPassthrough: !this.state.hostPassthrough });
+    }
+  }
+
+  handleCpuPinningChange = (index, value) => {
+    const cpuPinning = [...this.state.cpuPinning];
+    cpuPinning[index] = value;
+    this.setState({ cpuPinning });
+  }
+
+  handleRtPriorityChange = (e) => {
+    this.setState({ rtPriority: Math.max(1, parseInt(e.target.value, 10) || 1) });
+  }
+
+  handleEmulatorPinChange = (e) => {
+    this.setState({ emulatorPin: e.target.value });
+  }
+
+  handleMemorySizeChange = (e) => {
+    this.setState({ memorySize: Math.max(1, parseInt(e.target.value, 10) || 1) });
+  }
+
+  handleBalloonChange = () => {
+    this.setState({ isBalloonEnabled: !this.state.isBalloonEnabled });
+  }
+
+  handleBalloonMinAllocationChange = (e) => {
+    this.setState({ balloonMinAllocation: Math.max(1, parseInt(e.target.value, 10) || 1) });
+  }
+
+  handleHugepagesChange = () => {
+    this.setState({ isHugepagesEnabled: !this.state.isHugepagesEnabled });
+  }
+
+  handleHugepagesCountChange = (e) => {
+    this.setState({ hugepagesCount: Math.max(1, parseInt(e.target.value, 10) || 1) });
+  }
+
+  handleSerialConsoleChange = () => {
+    this.setState({ isSerialConsoleEnabled: !this.state.isSerialConsoleEnabled });
+  }
+
+  handleVideoChange = () => {
+    this.setState({ isVideoEnabled: !this.state.isVideoEnabled });
+  }
+
+  handleAddInterface = () => {
+    const newIface = {
+      id: this.state.nextInterfaceId,
+      type: 'bridge',
+      bridgeSource: '',
+      bridgeMac: '',
+      bridgeVlan: '',
+      bridgeVirtualportType: '',
+      networkName: '',
+      macvtapSource: '',
+      macvtapMode: 'vepa',
+      macvtapMac: '',
+      pciAddress: '',
+      sriovPool: '',
+    };
+    this.setState({
+      networkInterfaces: [...this.state.networkInterfaces, newIface],
+      nextInterfaceId: this.state.nextInterfaceId + 1,
+    });
+  }
+
+  handleRemoveInterface = (id) => {
+    this.setState({
+      networkInterfaces: this.state.networkInterfaces.filter((iface) => iface.id !== id),
+    });
+  }
+
+  handleInterfaceChange = (id, field, value) => {
+    this.setState({
+      networkInterfaces: this.state.networkInterfaces.map((iface) =>
+        iface.id === id ? { ...iface, [field]: value } : iface
+      ),
+    });
+  }
+
   handleConfirm = () => {
-    const { vmName, vmImagePath, vmXmlPath, diskBusType } = this.state;
+    const { vmName, vmImagePath, vmXmlPath, diskBusType, importXml } = this.state;
     const { refreshVMList } = this.props;
 
     const args = [];
@@ -81,6 +210,12 @@ class VMCreator extends React.Component {
     }else if (this.state.isPreferredHostEnabled){
       args.push('--preferred-host');
       args.push(this.state.locationHostname);
+    }
+
+    if (!importXml) {
+      // Form-based creation not yet implemented
+      console.warn("Form-based XML generation is not yet implemented");
+      return;
     }
 
     this.setState({ isLoading: true, isVMCreated: null });
@@ -124,13 +259,13 @@ class VMCreator extends React.Component {
 
   render() {
     const { isOpen, onClose } = this.props;
-    const { vmName, vmImagePath, vmXmlPath, isLoading, isVMCreated, progressUploadXML, progressUploadQCOW } = this.state;
+    const { vmName, vmImagePath, vmXmlPath, isLoading, isVMCreated, progressUploadXML, progressUploadQCOW, importXml } = this.state;
     const diskBusTypes = [ "sata", "scsi", "usb", "virtio" ];
 
     return (
       <Modal
         title="VM Creation"
-        variant={ModalVariant.small}
+        variant={importXml ? ModalVariant.small : ModalVariant.medium}
         isOpen={isOpen}
         onClose={onClose}
         actions={[
@@ -191,25 +326,85 @@ class VMCreator extends React.Component {
             </div>
           </FormGroup>
 
-          <FormGroup label="Path VM XML" fieldId="path-vm-xml">
-            <div style={{ display: 'flex', alignItems: 'center', marginBottom: '10px' }}>
-              <FileAutoComplete
-                id="path-vm-xml"
-                key={vmXmlPath} // Force the update: the modification of "vmXmlPath" by "handleCallback" do not change the value displayed
-                placeholder={"Path to XML file on host's file system"}
-                value={vmXmlPath}
-                onChange={this.handleVmXmlPathChange}
-                superuser="try"
+          <Checkbox
+            id="import-xml"
+            label="Import libvirt XML"
+            isChecked={importXml}
+            onChange={this.handleImportXmlChange}
+          />
+
+          {importXml ? (
+            <FormGroup label="Path VM XML" fieldId="path-vm-xml">
+              <div style={{ display: 'flex', alignItems: 'center', marginBottom: '10px' }}>
+                <FileAutoComplete
+                  id="path-vm-xml"
+                  key={vmXmlPath} // Force the update: the modification of "vmXmlPath" by "handleCallback" do not change the value displayed
+                  placeholder={"Path to XML file on host's file system"}
+                  value={vmXmlPath}
+                  onChange={this.handleVmXmlPathChange}
+                  superuser="try"
+                />
+                <FileUploader
+                  fileExtension=".xml"
+                  handleCallback={(filePath, fileExtension, progress) => this.handleCallback(filePath, fileExtension, progress)}
+                />
+              </div>
+              {progressUploadXML > 0 && (
+                <Progress value={progressUploadXML} />
+              )}
+            </FormGroup>
+          ) : (
+            <>
+              <Checkbox
+                id="enable-realtime"
+                label="Real-time"
+                isChecked={this.state.isRealtime}
+                onChange={this.handleRealtimeChange}
               />
-              <FileUploader
-                fileExtension=".xml"
-                handleCallback={(filePath, fileExtension, progress) => this.handleCallback(filePath, fileExtension, progress)}
+
+              <CPUConfig
+                vcpuCount={this.state.vcpuCount}
+                hostPassthrough={this.state.hostPassthrough}
+                isRealtime={this.state.isRealtime}
+                cpuPinning={this.state.cpuPinning}
+                rtPriority={this.state.rtPriority}
+                emulatorPin={this.state.emulatorPin}
+                onVcpuCountChange={this.handleVcpuCountChange}
+                onHostPassthroughChange={this.handleHostPassthroughChange}
+                onCpuPinningChange={this.handleCpuPinningChange}
+                onRtPriorityChange={this.handleRtPriorityChange}
+                onEmulatorPinChange={this.handleEmulatorPinChange}
               />
-            </div>
-            {progressUploadXML > 0 && (
-              <Progress value={progressUploadXML} />
-            )}
-          </FormGroup>
+
+              <MemoryConfig
+                memorySize={this.state.memorySize}
+                isRealtime={this.state.isRealtime}
+                isBalloonEnabled={this.state.isBalloonEnabled}
+                balloonMinAllocation={this.state.balloonMinAllocation}
+                isHugepagesEnabled={this.state.isHugepagesEnabled}
+                hugepagesCount={this.state.hugepagesCount}
+                onMemorySizeChange={this.handleMemorySizeChange}
+                onBalloonChange={this.handleBalloonChange}
+                onBalloonMinAllocationChange={this.handleBalloonMinAllocationChange}
+                onHugepagesChange={this.handleHugepagesChange}
+                onHugepagesCountChange={this.handleHugepagesCountChange}
+              />
+
+              <DisplayConfig
+                isSerialConsoleEnabled={this.state.isSerialConsoleEnabled}
+                isVideoEnabled={this.state.isVideoEnabled}
+                onSerialConsoleChange={this.handleSerialConsoleChange}
+                onVideoChange={this.handleVideoChange}
+              />
+
+              <NetworkConfig
+                networkInterfaces={this.state.networkInterfaces}
+                onAddInterface={this.handleAddInterface}
+                onRemoveInterface={this.handleRemoveInterface}
+                onInterfaceChange={this.handleInterfaceChange}
+              />
+            </>
+          )}
 
           <Checkbox
             id="enable-live-migration"


### PR DESCRIPTION
## Summary

- Add a form-based VM creation flow as an alternative to importing a libvirt XML, with sub-components for CPU, memory, display and network configuration.
- Wire that form to the new \`vm-mgr create\` CLI flags introduced in vm_manager (\`--vcpus\`, \`--memory\`, \`--cpuset\`, \`--rt\`, \`--rt-priority\`, \`--emulatorpin\`, \`--hugepages\`, \`--balloon\`, \`--vnc\`, repeated \`--net …\`) so the form can actually create VMs without a pre-existing XML.

Requires the matching \`vm_manager\` change ("Add XML generator to create libvirt domain XML from CLI options"). The legacy "Import libvirt XML" toggle still works and continues to pass \`--xml\`.

## Known gaps

These UI controls are collected but not yet honored by \`vm-mgr\` / \`xml_generator\`:

- \`hostPassthrough\` checkbox outside RT mode (CLI only emits host-passthrough when \`--rt\` is set)
- \`balloonMinAllocation\` and \`hugepagesCount\` (generator hard-codes their values)
- \`isSerialConsoleEnabled\` (serial+console are always emitted)
- No UI fields for \`--secure-boot\`, \`--vnc-listen\`, \`--description\`
- The \`ovs\` net type from the CLI parser is not yet exposed in NetworkConfig
- Removed the "Libvirt network" interface entry since the CLI \`--net\` parser has no matching type

## Test plan

- [ ] \`npm run init && npm run build\` succeeds
- [ ] Deploy \`dist/\` to a SEAPATH cluster node and open Cockpit → VM management → "Create VM"
- [ ] With "Import libvirt XML" off: fill name + qcow2 + vCPUs + memory + one bridge interface, click Apply, confirm the VM is created and \`virsh dumpxml <name>\` matches expectations
- [ ] Repeat with \`--rt\` enabled and a cpuset to verify the realtime path
- [ ] With "Import libvirt XML" on: confirm the legacy XML-based creation still works